### PR TITLE
Updated Lucene.Net 4.8.0-beta00011

### DIFF
--- a/source/Lucene.Net.Store.Azure.Tests/Lucene.Net.Store.Azure.Tests.csproj
+++ b/source/Lucene.Net.Store.Azure.Tests/Lucene.Net.Store.Azure.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-beta00007" />
+    <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-beta00011" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0-preview-20190828-03" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />

--- a/source/Lucene.Net.Store.Azure/AzureIndexOutput.cs
+++ b/source/Lucene.Net.Store.Azure/AzureIndexOutput.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Threading;
-using Lucene.Net.Index;
-using Lucene.Net.Store;
-using Lucene.Net.Support;
 using Microsoft.Azure.Storage.Blob;
 
 namespace Lucene.Net.Store.Azure
@@ -21,7 +16,6 @@ namespace Lucene.Net.Store.Azure
         private IndexOutput _indexOutput;
         private Mutex _fileMutex;
         private ICloudBlob _blob;
-        private readonly CRC32 _crc;
 
         public AzureIndexOutput(AzureDirectory azureDirectory, string name, CloudBlockBlob blob)
         {
@@ -41,7 +35,6 @@ namespace Lucene.Net.Store.Azure
             {
                 _fileMutex.ReleaseMutex();
             }
-            _crc = new CRC32();
         }
 
         public Lucene.Net.Store.Directory CacheDirectory { get { return _azureDirectory.CacheDirectory; } }
@@ -88,30 +81,21 @@ namespace Lucene.Net.Store.Azure
             }
         }
 
-        public override long Length
-        {
-            get
-            {
-                return _indexOutput.Length;
-            }
-        }
+        public override long Length => _indexOutput.Length;
 
         public override void WriteByte(byte b)
         {
             _indexOutput.WriteByte(b);
-            _crc.Update(new byte[] { b }, 0, 1);
         }
 
         public override void WriteBytes(byte[] b, int length)
         {
             _indexOutput.WriteBytes(b, length);
-            _crc.Update(b, 0, length);
         }
 
         public override void WriteBytes(byte[] b, int offset, int length)
         {
             _indexOutput.WriteBytes(b, offset, length);
-            _crc.Update(b, offset, length);
         }
 
         public override long GetFilePointer()
@@ -124,6 +108,6 @@ namespace Lucene.Net.Store.Azure
             //_indexOutput.Seek(pos);
         }
 
-        public override long Checksum => _crc.Value;
+        public override long Checksum => _indexOutput.Checksum;
     }
 }

--- a/source/Lucene.Net.Store.Azure/Lucene.Net.Store.Azure.csproj
+++ b/source/Lucene.Net.Store.Azure/Lucene.Net.Store.Azure.csproj
@@ -3,19 +3,19 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.8.0-beta007</Version>
+    <Version>4.8.0-beta0011</Version>
     <Authors>Tom Laird-McConnell</Authors>
     <Title>Azure blob storage for Lucene.net</Title>
     <Summary>This project allows you to store Lucene Indexes in by Azure BlobStorage.</Summary>
-    <Description>This project allows you to create Lucene Indexes via a AzureDirectory object which uses Azure BlobStorage for persistent storage.  This .NET Standard compliant library for us with .NET Core or .NET Desktop. It uses Lucene.Net 4.8.0.beta0007</Description>
+    <Description>This project allows you to create Lucene Indexes via a AzureDirectory object which uses Azure BlobStorage for persistent storage.  This .NET Standard compliant library for us with .NET Core or .NET Desktop. It uses Lucene.Net 4.8.0.beta00011</Description>
     <PackageLicenseFile></PackageLicenseFile>
     <PackageProjectUrl>https://github.com/tomlm/Lucene.Net.Store.Azure</PackageProjectUrl>
     <RepositoryUrl>https://github.com/tomlm/Lucene.Net.Store.Azure</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
-    <AssemblyVersion>4.8.0.9</AssemblyVersion>
-    <FileVersion>4.8.0.9</FileVersion>
-    <PackageReleaseNotes>This is a release with dependency on Lucene.Net 4.8.0.beta 007</PackageReleaseNotes>
+    <AssemblyVersion>4.8.0.10</AssemblyVersion>
+    <FileVersion>4.8.0.10</FileVersion>
+    <PackageReleaseNotes>This is a release with dependency on Lucene.Net 4.8.0.beta 0011</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lucene.Net" Version="4.8.0-beta00007" />
-    <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00007" />
+    <PackageReference Include="Lucene.Net" Version="4.8.0-beta00011" />
+    <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00011" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.2" />
   </ItemGroup>
 


### PR DESCRIPTION
The latest Lucene.Net 4.8.0 beta has the CRC32 class internalized.
Looking at the code of the IndexOutput, it looks like we can just use that checksum.