### PR TITLE
Writing two consecutive times to an index with subdirectory somehow c…

### DIFF
--- a/source/Lucene.Net.Store.Azure.Tests/AzureDirectoryTests.cs
+++ b/source/Lucene.Net.Store.Azure.Tests/AzureDirectoryTests.cs
@@ -34,10 +34,6 @@ namespace Lucene.Net.Store.Azure.Tests
 
             var azureDirectory = new AzureDirectory(connectionString, containerName);
 
-            var indexWriterConfig = new IndexWriterConfig(
-                Lucene.Net.Util.LuceneVersion.LUCENE_48,
-                new StandardAnalyzer(Lucene.Net.Util.LuceneVersion.LUCENE_48));
-
             var (dog, cat, car) = InitializeCatalog(azureDirectory, 1000);
 
             try
@@ -72,6 +68,47 @@ namespace Lucene.Net.Store.Azure.Tests
         public void TestReadAndWriteWithSubDirectory()
         {
             var connectionString = _connectionString ?? "UseDevelopmentStorage=true";
+            const string containerName = "testcatalog";
+            var blobClient = new BlobServiceClient(connectionString);
+            var container = blobClient.GetBlobContainerClient(containerName);
+            container.DeleteIfExists();
+
+            var azureDirectory = new AzureDirectory(connectionString, $"{containerName}/subdirectory");
+
+            var (dog, cat, car) = InitializeCatalog(azureDirectory, 1000);
+
+            try
+            {
+
+                var ireader = DirectoryReader.Open(azureDirectory);
+                for (var i = 0; i < 100; i++)
+                {
+                    var searcher = new IndexSearcher(ireader);
+                    var searchForPhrase = SearchForPhrase(searcher, "dog");
+                    Assert.AreEqual(dog, searchForPhrase);
+                    searchForPhrase = SearchForPhrase(searcher, "cat");
+                    Assert.AreEqual(cat, searchForPhrase);
+                    searchForPhrase = SearchForPhrase(searcher, "car");
+                    Assert.AreEqual(car, searchForPhrase);
+                }
+                Trace.TraceInformation("Tests passsed");
+            }
+            catch (Exception x)
+            {
+                Trace.TraceInformation("Tests failed:\n{0}", x);
+            }
+            finally
+            {
+                // check the container exists, and delete it
+                Assert.IsTrue(container.Exists()); // check the container exists
+                container.Delete();
+            }
+        }
+        
+        [TestMethod]
+        public void TestReadAndWriteWithTwoShardDirectories()
+        {
+            var connectionString = _connectionString ?? "UseDevelopmentStorage=true";
             const string containerName = "testcatalogwithshards";
             var blobClient = new BlobServiceClient(connectionString);
             var container = blobClient.GetBlobContainerClient(containerName);
@@ -98,9 +135,264 @@ namespace Lucene.Net.Store.Azure.Tests
                 azureDirectory2.DeleteFile(file);
             }
         }
+        
+        [TestMethod]
+        public void TestReadAndWrite_WritingTwoConsecutiveTimes()
+        {
+
+            var connectionString = _connectionString ?? "UseDevelopmentStorage=true";
+            const string containerName = "testcatalog";
+            var blobClient = new BlobServiceClient(connectionString);
+            var container = blobClient.GetBlobContainerClient(containerName);
+            container.DeleteIfExists();
+
+            var azureDirectory = new AzureDirectory(connectionString, containerName);
+
+            var (dog, cat, car) = InitializeCatalog(azureDirectory, 500);
+            var (dog1, cat1, car1) = InitializeCatalog(azureDirectory, 500);
+            dog += dog1;
+            cat += cat1;
+            car += car1;
+
+            try
+            {
+                var ireader = DirectoryReader.Open(azureDirectory);
+                for (var i = 0; i < 100; i++)
+                {
+                    var searcher = new IndexSearcher(ireader);
+                    var searchForPhrase = SearchForPhrase(searcher, "dog");
+                    Assert.AreEqual(dog, searchForPhrase);
+                    searchForPhrase = SearchForPhrase(searcher, "cat");
+                    Assert.AreEqual(cat, searchForPhrase);
+                    searchForPhrase = SearchForPhrase(searcher, "car");
+                    Assert.AreEqual(car, searchForPhrase);
+                }
+                Trace.TraceInformation("Tests passsed");
+            }
+            catch (Exception x)
+            {
+                Trace.TraceInformation("Tests failed:\n{0}", x);
+            }
+            finally
+            {
+                // check the container exists, and delete it
+                Assert.IsTrue(container.Exists()); // check the container exists
+                container.Delete();
+            }
+        }
+
+        [TestMethod]
+        public void TestReadAndWriteWithSubDirectory_WritingTwoConsecutiveTimes()
+        {
+            var connectionString = _connectionString ?? "UseDevelopmentStorage=true";
+            const string containerName = "testcatalog";
+            var blobClient = new BlobServiceClient(connectionString);
+            var container = blobClient.GetBlobContainerClient(containerName);
+            container.DeleteIfExists();
+
+            var azureDirectory = new AzureDirectory(connectionString, $"{containerName}/subdirectory");
+
+            var (dog, cat, car) = InitializeCatalog(azureDirectory, 500);
+            var (dog1, cat1, car1) = InitializeCatalog(azureDirectory, 500);
+            dog += dog1;
+            cat += cat1;
+            car += car1;
+
+            try
+            {
+
+                var ireader = DirectoryReader.Open(azureDirectory);
+                for (var i = 0; i < 100; i++)
+                {
+                    var searcher = new IndexSearcher(ireader);
+                    var searchForPhrase = SearchForPhrase(searcher, "dog");
+                    Assert.AreEqual(dog, searchForPhrase);
+                    searchForPhrase = SearchForPhrase(searcher, "cat");
+                    Assert.AreEqual(cat, searchForPhrase);
+                    searchForPhrase = SearchForPhrase(searcher, "car");
+                    Assert.AreEqual(car, searchForPhrase);
+                }
+                Trace.TraceInformation("Tests passsed");
+            }
+            catch (Exception x)
+            {
+                Trace.TraceInformation("Tests failed:\n{0}", x);
+            }
+            finally
+            {
+                // check the container exists, and delete it
+                Assert.IsTrue(container.Exists()); // check the container exists
+                container.Delete();
+            }
+        }
+        
+        [TestMethod]
+        public void TestReadAndWriteWithTwoShardDirectories_WritingTwoConsecutiveTimes()
+        {
+            var connectionString = _connectionString ?? "UseDevelopmentStorage=true";
+            const string containerName = "testcatalogwithshards";
+            var blobClient = new BlobServiceClient(connectionString);
+            var container = blobClient.GetBlobContainerClient(containerName);
+            container.DeleteIfExists();
+
+            var azureDirectory1 = new AzureDirectory(connectionString, $"{containerName}/shard1");
+            var (dog, cat, car) = InitializeCatalog(azureDirectory1, 500);
+            var (dog1, cat1, car1) = InitializeCatalog(azureDirectory1, 500);
+            dog += dog1;
+            cat += cat1;
+            car += car1;
+            
+            var azureDirectory2 = new AzureDirectory(connectionString, $"{containerName}/shard2");
+            var (dog2, cat2, car2) = InitializeCatalog(azureDirectory2, 250);
+            var (dog3, cat3, car3) = InitializeCatalog(azureDirectory2, 250);
+            dog2 += dog3;
+            cat2 += cat3;
+            car2 += car3;
+
+            ValidateDirectory(azureDirectory1, dog, cat, car);
+            ValidateDirectory(azureDirectory2, dog2, cat2, car2);
+
+            // delete all azureDirectory1 blobs
+            foreach (string file in azureDirectory1.ListAll())
+            {
+                azureDirectory1.DeleteFile(file);
+            }
+
+            ValidateDirectory(azureDirectory2, dog2, cat2, car2);
+
+            foreach (string file in azureDirectory2.ListAll())
+            {
+                azureDirectory2.DeleteFile(file);
+            }
+        }
+
+        [TestMethod]
+        public void CanListAllFileNames_InFlatContainer()
+        {
+            // Arrange
+            var expectedFileNames = string.Join("\n", new[]
+            {
+                "_0.cfe",
+                "_0.cfs",
+                "_0.si",
+                "segments.gen",
+                "segments_1",
+                "write.lock"
+            });
+            TestListingFilesOfDirectory("testcatalog", expectedFileNames);
+        }
+        
+        [TestMethod]
+        public void CanListAllFileNames_InLevel1Subdirectory()
+        {
+            // Arrange
+            var expectedFileNames = string.Join("\n", new[]
+            {
+                "_0.cfe",
+                "_0.cfs",
+                "_0.si",
+                "segments.gen",
+                "segments_1",
+                "write.lock"
+            });
+            TestListingFilesOfDirectory("testcatalog/shard1", expectedFileNames);
+        }
+        
+        [TestMethod]
+        public void CanListAllFileNames_InLevel2Subdirectory()
+        {
+            // Arrange
+            var expectedFileNames = string.Join("\n", new[]
+            {
+                "_0.cfe",
+                "_0.cfs",
+                "_0.si",
+                "segments.gen",
+                "segments_1",
+                "write.lock"
+            });
+            TestListingFilesOfDirectory("testcatalog/shard1/level2", expectedFileNames);
+        }
+        
+        [TestMethod]
+        public void CanListAllFileNames_InFlatContainer_After2Writes()
+        {
+            // Arrange
+            var expectedFileNames = string.Join("\n", new[]
+            {
+               "_0.cfe",
+               "_0.cfs",
+               "_0.si",
+               "_1.cfe",
+               "_1.cfs",
+               "_1.si",
+               "segments_2",
+               "write.lock",
+            });
+            TestListingFilesOfDirectory("testcatalog", expectedFileNames, numberOfSimulatedIndexWrites:2);
+        }
+        
+        [TestMethod]
+        public void CanListAllFileNames_InLevel1Subdirectory_After2Writes()
+        {
+            // Arrange
+            var expectedFileNames = string.Join("\n", new[]
+            {
+                "_0.cfe",
+                "_0.cfs",
+                "_0.si",
+                "_1.cfe",
+                "_1.cfs",
+                "_1.si",
+                "segments_2",
+                "write.lock",
+            });
+            TestListingFilesOfDirectory("testcatalog/shard1", expectedFileNames, numberOfSimulatedIndexWrites:2);
+        }
+        
+        [TestMethod]
+        public void CanListAllFileNames_InLevel2Subdirectory_After2Writes()
+        {
+            // Arrange
+            var expectedFileNames = string.Join("\n", new[]
+            {
+                "_0.cfe",
+                "_0.cfs",
+                "_0.si",
+                "_1.cfe",
+                "_1.cfs",
+                "_1.si",
+                "segments_2",
+                "write.lock",
+            });
+            TestListingFilesOfDirectory("testcatalog/shard1/level2", expectedFileNames, numberOfSimulatedIndexWrites:2);
+        }
+
+        private void TestListingFilesOfDirectory(string containerName, string expectedFileNames, int numberOfSimulatedIndexWrites = 1)
+        {
+            var connectionString = _connectionString ?? "UseDevelopmentStorage=true";
+            var blobClient = new BlobServiceClient(connectionString);
+            var container = blobClient.GetBlobContainerClient(containerName);
+            container.DeleteIfExists();
+
+            var azureDirectory = new AzureDirectory(connectionString, containerName);
+
+            for (int i = 0; i < numberOfSimulatedIndexWrites; i++)
+            {
+                InitializeCatalog(azureDirectory, 1000/numberOfSimulatedIndexWrites);
+            }
+            
+            // Act
+            var actual = azureDirectory.ListAll();
+
+            // Assert
+            var actualFileNames = string.Join("\n", actual);
+            Assert.AreEqual(expectedFileNames, actualFileNames);
+        }
 
         private static void ValidateDirectory(AzureDirectory azureDirectory2, Int32 dog2, Int32 cat2, Int32 car2)
         {
+            System.Diagnostics.Debug.WriteLine("--------- DirectoryReader ---------");
             var ireader = DirectoryReader.Open(azureDirectory2);
             for (var i = 0; i < 100; i++)
             {

--- a/source/Lucene.Net.Store.Azure/AzureDirectory.cs
+++ b/source/Lucene.Net.Store.Azure/AzureDirectory.cs
@@ -113,10 +113,10 @@ namespace Lucene.Net.Store.Azure
         /// <summary>Returns an array of strings, one for each file in the directory. </summary>
         public override string[] ListAll()
         {
-            var results = Enumerable.Empty<string>();
-            return BlobContainer.GetBlobsByHierarchy(delimiter: "/", prefix: this.subDirectory)
+            var prefix = string.IsNullOrEmpty(this.subDirectory) ? null : this.subDirectory + "/";
+            return BlobContainer.GetBlobsByHierarchy(delimiter: "/", prefix: prefix)
                 .Where(x => x.IsBlob)
-                .Select(x => x.Blob.Name).ToArray();
+                .Select(x => x.Blob.Name.Split('/').Last()).ToArray();
         }
 
         /// <summary>Returns true if a file with the given name exists. </summary>


### PR DESCRIPTION
I added two tests where the only thing I changed is, that both write two times to the index.
If there is no subdirectory specified, this works fine

If there is one, however, it somehow causes the "segments.gen" file to vanish and the directoryreader throws an exception.
![image](https://github.com/user-attachments/assets/b0b74a0d-b0a8-44ca-9e68-03ebe4156780)

However, there seems to be a "segments_2" file now, but it is not picked up.
![image](https://github.com/user-attachments/assets/90a87a7f-aa39-427d-b250-9fed6b3cf310)

As it turns out, the ListAll method of AzureDirectory contained a bug. The prefix was missing a trailing forward slash "/" causing the blobclient to not return anything instead of the list of files of the directory.

I added additional tests to verify that this works now.

I do hope you like it. Cheers!