### PR TITLE
Improve tests by comparing to a reference FSDirectory (files and contents - except *.si files as they contain a timestamp)

### DIFF
--- a/source/Lucene.Net.Store.Azure/AzureDirectory.cs
+++ b/source/Lucene.Net.Store.Azure/AzureDirectory.cs
@@ -140,6 +140,7 @@ namespace Lucene.Net.Store.Azure
             var blobName = GetBlobName(name);
             var blob = BlobContainer.GetBlobClient(blobName);
             blob.DeleteIfExists();
+            
         }
 
         /// <summary>Returns the length of a file in the directory. </summary>


### PR DESCRIPTION
Hi!

I just hardened your AzureDirectoryTests by introducing a reference directory (`FSDirectory`) that all tests write to too.
Then, I can go and verify that
- all files in the `FSDirectory`, also exist in the `AzureDirectory` and its `CacheDirectory`
- and I can compare the files binary too.

That way I also found out that you are not removing the `"write.lock"` file. Was that by purpose?

Here is my PR.
I do hope you like it!